### PR TITLE
FIX utf-8 warning with xetex/luatex engines

### DIFF
--- a/beamerthemeArguelles.sty
+++ b/beamerthemeArguelles.sty
@@ -34,7 +34,19 @@
 \fi
 
 % package dependencies
-\RequirePackage[utf8]{inputenc}
+\RequirePackage{ifluatex}
+\RequirePackage{ifxetex}
+% Load inputenc only for pdfLaTeX
+\ifluatex
+  % LuaTeX, no inputenc needed
+\else
+  \ifxetex
+    % XeLaTeX, no inputenc needed
+  \else
+    % pdfLaTeX, load inputenc
+    \RequirePackage[utf8]{inputenc}
+  \fi
+\fi
 \RequirePackage[T1]{fontenc}
 \RequirePackage[osf]{Alegreya}
 \RequirePackage[osf]{AlegreyaSans}


### PR DESCRIPTION
When using xetex or luatex, the compilation produces the warning 

> Package inputenc Warning: inputenc package ignored with utf8 based engines.

This fix suppresses the warning by checking the running TeX engine, and avoid loading `inputenc` when it is not needed.