### PR TITLE
Add venue to the title page

### DIFF
--- a/beamerfontthemeArguelles.sty
+++ b/beamerfontthemeArguelles.sty
@@ -20,6 +20,7 @@
   \setbeamerfont{subtitle}{series=\AlegreyaSansMedium,size=\Large}
 \fi
 \setbeamerfont{event}{series=\itshape}
+\setbeamerfont{venue}{series=\itshape}
 \setbeamerfont{date}{series=\itshape}
 \setbeamerfont{author}{series=\bfseries,size=\large}
 \setbeamerfont{institute}{size=\small}

--- a/beamerinnerthemeArguelles.sty
+++ b/beamerinnerthemeArguelles.sty
@@ -13,6 +13,10 @@
 \newcommand{\event}[1]{
   \def\insertevent{#1}
 }
+\def\insertvenue{}
+\newcommand{\venue}[1]{
+  \def\insertvenue{#1}
+}
 \def\insertemail{}
 \newcommand{\email}[1]{
   \def\insertemail{\href{mailto:#1}{\raisebox{-.1em}{\faIcon{envelope}}\hspace{.3em}#1}}
@@ -32,6 +36,7 @@
     {\usebeamerfont{title}\inserttitle}\par
     {\usebeamerfont{subtitle}\insertsubtitle}\par\bigskip
     {\usebeamerfont{event}\insertevent}\par
+    {\usebeamerfont{venue}\insertvenue}\par
     {\usebeamerfont{date}\insertdate}\par\bigskip
     {\usebeamerfont{author}\insertauthor}\par\smallskip
     {\usebeamerfont{institute}\insertinstitute}\par

--- a/demo/demo-arguelles.tex
+++ b/demo/demo-arguelles.tex
@@ -10,6 +10,7 @@
 \title{Argüelles}
 \subtitle{Simple, typographic beamer theme}
 \event{}
+\venue{}
 \date{}
 \author{Place Holder}
 \institute{University of \TeX}


### PR DESCRIPTION
I found that I write `\event{The 42nd Great Workshop\\Beautiful Place, State, Country}` everytime. This PR adds the dedicated field for venue.

Thank you so much for your beautiful theme! I use Argüelles in weekly meetings, workshops, community events, and so on, for years.