### PR TITLE
FIX skip eulervm when unicode-math is loaded

### DIFF
--- a/beamerthemeArguelles.sty
+++ b/beamerthemeArguelles.sty
@@ -55,7 +55,14 @@
 \else
   \RequirePackage[osf]{Alegreya}
   \RequirePackage[osf]{AlegreyaSans}
-  \RequirePackage[euler-hat-accent]{eulervm}
+  % Load eulervm only when unicode-math is NOT active
+  \makeatletter
+  \@ifpackageloaded{unicode-math}{
+    % unicode-math loaded → skip legacy eulervm
+  }{
+    \RequirePackage[euler-hat-accent]{eulervm}
+  }
+  \makeatother
 \fi
 \RequirePackage[bb=px]{mathalpha}
 \RequirePackage[nopatch=footnote]{microtype}


### PR DESCRIPTION
Added conditional check to avoid loading eulervm when unicode-math is present, resolving math font conflicts and warnings.